### PR TITLE
Fix pandas 3.0 / numpy 2 compatibility

### DIFF
--- a/pyOASIS/RNX_CLEAN.py
+++ b/pyOASIS/RNX_CLEAN.py
@@ -1252,7 +1252,13 @@ def RNXScreening(destination_directory):
             )
 
         for c in ['cs_flag','outlier_flag']:
-            df_selecionado[c] = pd.to_numeric(df_selecionado[c], errors='ignore')
+            # Preserve semantics of pandas' legacy `errors='ignore'` (removed in
+            # pandas 3.0): convert the column only if every value is numeric,
+            # otherwise leave it untouched.
+            try:
+                df_selecionado[c] = pd.to_numeric(df_selecionado[c], errors='raise')
+            except (ValueError, TypeError):
+                pass
 
         df_selecionado.to_csv(
             output_file_path,

--- a/pyOASIS/RNX_LEVELLING.py
+++ b/pyOASIS/RNX_LEVELLING.py
@@ -335,7 +335,7 @@ def process_gf_combination(L_GF, P_GF, arcos, df, sat_class, satellite,
     }).sort_values("timestamp").set_index("timestamp")
 
     ts = df_interp.index.values.astype("datetime64[s]").astype("int64")
-    y = df_interp["L_GF"].to_numpy(dtype=float)
+    y = df_interp["L_GF"].to_numpy(dtype=float, copy=True)
     MAX_GAP_SECONDS = 30 * 60
     n = len(y)
     i = 0

--- a/pyOASIS/TEC_CAL.py
+++ b/pyOASIS/TEC_CAL.py
@@ -574,7 +574,7 @@ def TECcalc(station: str,
             vertically reconnecting STEC and VTEC arcs, and plot STEC/VTEC/IPP.
             """
             col_names = ['sat', 'mjd', 'stec', 'lon', 'lat', 'elevation', 'azimuth', 'vtec']
-            df_plot = pd.read_csv(file_path, delim_whitespace=True, header=None, names=col_names)
+            df_plot = pd.read_csv(file_path, sep=r'\s+', header=None, names=col_names)
 
             # Convert MJD to datetime and UT hour
             df_plot['datetime'] = df_plot['mjd'].apply(mjd_to_datetime)


### PR DESCRIPTION
  ## Summary                                                                                                                                                                      
                                                                                                                                                                                  
  Three independent bugfixes that let the pipeline run end-to-end on pandas ≥ 3.0 and numpy ≥ 2.0 without changing behaviour on older versions. Each is a minimal, one-line (or few-line) change, addressed in its own atomic commit.                                                                                                                                                       
                                                                                                                                                                                  
  | Commit | File | Root cause |                                                                                                                                                  
  |---|---|---|                                                   
  | `a9d59a0c` | `RNX_CLEAN.py` | `pd.to_numeric(errors='ignore')` was removed in pandas 3.0 — `RNXScreening` raises `ValueError: invalid error value specified`, aborting        
  `RNXclean`. |                                                                                                                                                                   
  | `1767fe7c` | `RNX_LEVELLING.py` | `df["L_GF"].to_numpy(dtype=float)` returns a read-only view in recent pandas/numpy; the in-place `y[k] = …` in `process_gf_combination`
  crashes with `ValueError: assignment destination is read-only`. |                                                                                                               
  | `540df41e` | `TEC_CAL.py` | `pd.read_csv(delim_whitespace=True)` was removed in pandas 3.0 — `plot_tec_results` fails with `TypeError: unexpected keyword argument
  'delim_whitespace'`. |                                                                                                                                                          
                                                                  
  ## Test plan                                                                                                                                                                    
                                                                  
Ran the full `main.py` pipeline with the bundled BOAV / 2023 / DOY 049 example on two environments:
                                                                                                                                                                                 
  - Python 3.12 · pandas **2.2.3** · numpy 1.26.4 (pre-patch unaffected)                                                                                                          
  - Python 3.12 · pandas **3.0.2** · numpy 2.4.4 (pre-patch fails; post-patch OK)
  - Both produce identical `.RNX1` / `.RNX2` / `.RNX3` files and the expected ROTI / ΔTEC / SIDX / TEC plots. No behavioural change on older pandas.                                                                                                                                                                   
                                                                  
  ## Out of scope                                                                                                                                                                 
                                                                  
  - The `SIDXcalc` positional RNX3 reader breaks because `RNX_LEVELLING` currently omits the `LGF_combination15` column from the export (see`RNX_LEVELLING.py:946`). This is an unrelated data-format issue — I'll open a separate issue/PR for it.                                                                                                                                              
  - No changes to `requirements.txt` / `pyproject.toml`: the patches preserve compatibility across the already-declared dependency range. 